### PR TITLE
Apply getIndexFromDomainPoint in operator() and setValue()

### DIFF
--- a/src/DGtal/images/ImageContainerByITKImage.h
+++ b/src/DGtal/images/ImageContainerByITKImage.h
@@ -193,10 +193,10 @@ namespace DGtal
       /**
        * Get the value of an image at a given position.
        *
-       * @param indexPoint  position in the image.
+       * @param domainPoint  position in the image.
        * @return the value at indexPoint.
        */
-      Value operator()(const Point &indexPoint) const;
+      Value operator()(const Point &domainPoint) const;
 
       /**
        * Get the value of an image at a given position.
@@ -215,12 +215,12 @@ namespace DGtal
       Value operator()(const Iterator &it) const;
 
       /**
-       * Set a value on an Image at indexPoint.
+       * Set a value on an Image at domainPoint.
        *
-       * @param indexPoint location of the point to associate with aValue.
+       * @param domainPoint location of the point to associate with aValue.
        * @param aValue the value.
        */
-      void setValue(const Point &indexPoint, const Value &aValue);
+      void setValue(const Point &domainPoint, const Value &aValue);
 
       /**
        * Set a value on an Image at a given position

--- a/src/DGtal/images/ImageContainerByITKImage.h
+++ b/src/DGtal/images/ImageContainerByITKImage.h
@@ -348,17 +348,19 @@ namespace DGtal
       // ------------------------- PhysicalPoint interface ----------------------
 
       /**
-       * Get PhysicalPoints from index and viceversa.
+       * Get PhysicalPoints from a domain point in DGtal and viceversa.
        *
        * Remember that GetOrigin() in ITK is the physical location of
        * the index {0,0...}. Not the location of the start index of the region.
        *
-       * @param indexPoint a point holding valid index coordinates of the ITK image.
+       * @param domainPoint a point holding a point in the DGtal domain.
+       * It will be converted to a valid index of the ITK image, taking into
+       * account the value of myDomainShift.
        * @return physical point of the index.
        */
-      inline PhysicalPoint getPhysicalPointFromIndex(const Point &indexPoint) const;
+      inline PhysicalPoint getPhysicalPointFromDomainPoint(const Point &domainPoint) const;
 
-      inline Point getIndexFromPhysicalPoint(const PhysicalPoint &physicalPoint) const;
+      inline Point getDomainPointFromPhysicalPoint(const PhysicalPoint &physicalPoint) const;
 
       /**
        * Returns the lower and upper bounds as physical points.

--- a/src/DGtal/images/ImageContainerByITKImage.ih
+++ b/src/DGtal/images/ImageContainerByITKImage.ih
@@ -117,12 +117,9 @@ namespace DGtal
     template <typename TDomain, typename TValue>
     inline
     TValue
-    ImageContainerByITKImage<TDomain, TValue>::operator()(const Point &indexPoint) const
+    ImageContainerByITKImage<TDomain, TValue>::operator()(const Point &domainPoint) const
     {
-      typename ITKImage::IndexType p;
-      for (Dimension k = 0; k < dimension; k++)
-        p[k] = indexPoint[k];
-      return myITKImagePointer->GetPixel(p);
+      return myITKImagePointer->GetPixel(getItkIndexFromDomainPoint(domainPoint));
     }
 
     /**
@@ -170,12 +167,9 @@ namespace DGtal
     template <typename Domain, typename T>
     inline
     void
-    ImageContainerByITKImage<Domain, T>::setValue(const Point &indexPoint, const T &V)
+    ImageContainerByITKImage<Domain, T>::setValue(const Point &domainPoint, const T &V)
     {
-      typename ITKImage::IndexType p;
-      for (Dimension k = 0; k < dimension; k++)
-        p[k] = indexPoint[k];
-      myITKImagePointer->SetPixel(p, V);
+      myITKImagePointer->SetPixel(getItkIndexFromDomainPoint(domainPoint), V);
     }
 
     template <typename Domain, typename T>

--- a/src/DGtal/images/ImageContainerByITKImage.ih
+++ b/src/DGtal/images/ImageContainerByITKImage.ih
@@ -246,13 +246,11 @@ namespace DGtal
     template<typename TDomain, typename TValue>
     inline
     typename ImageContainerByITKImage<TDomain, TValue>::PhysicalPoint
-    ImageContainerByITKImage<TDomain, TValue>::getPhysicalPointFromIndex(const Point &indexPoint) const
+    ImageContainerByITKImage<TDomain, TValue>::getPhysicalPointFromDomainPoint(const Point &domainPoint) const
     {
-      // Transform input Point to itk Index
-      typename ITKImage::IndexType itk_index;
-      for (Dimension k = 0; k < dimension; k++)
-        itk_index[k] = indexPoint[k];
-
+      // Transform input Point to itk Index.
+      // The index would be different than the domain point if myDomainShift is not zero.
+      const auto itk_index = getItkIndexFromDomainPoint(domainPoint);
       // ITK performs the transform between index and physical spaces.
       const typename ITKImage::PointType itk_point =
         myITKImagePointer->template TransformIndexToPhysicalPoint<typename RealPoint::Component>(itk_index);
@@ -268,7 +266,7 @@ namespace DGtal
     template<typename TDomain, typename TValue>
     inline
     typename ImageContainerByITKImage<TDomain, TValue>::Point
-    ImageContainerByITKImage<TDomain, TValue>::getIndexFromPhysicalPoint(const PhysicalPoint &physicalPoint) const
+    ImageContainerByITKImage<TDomain, TValue>::getDomainPointFromPhysicalPoint(const PhysicalPoint &physicalPoint) const
     {
       // Transform input dgtal point to itk point (real points)
       typename ITKImage::PointType itk_point;
@@ -279,19 +277,15 @@ namespace DGtal
       const typename ITKImage::IndexType itk_index =
         myITKImagePointer->TransformPhysicalPointToIndex(itk_point);
 
-      // Transform itk index to dgtal index
-      Point dgtal_index;
-      for (Dimension k = 0; k < dimension; k++)
-        dgtal_index[k] = itk_index[k];
-
-      return dgtal_index;
+      return getDomainPointFromItkIndex(itk_index);
     }
+
     template<typename TDomain, typename TValue>
     inline
     typename ImageContainerByITKImage<TDomain, TValue>::PhysicalPoint
     ImageContainerByITKImage<TDomain, TValue>::getLowerBoundAsPhysicalPoint() const
     {
-      return getPhysicalPointFromIndex(getIndexFromDomainPoint(myDomain.lowerBound()));
+      return getPhysicalPointFromDomainPoint(myDomain.lowerBound());
     }
 
     template<typename TDomain, typename TValue>
@@ -299,7 +293,7 @@ namespace DGtal
     typename ImageContainerByITKImage<TDomain, TValue>::PhysicalPoint
     ImageContainerByITKImage<TDomain, TValue>::getUpperBoundAsPhysicalPoint() const
     {
-      return getPhysicalPointFromIndex(getIndexFromDomainPoint(myDomain.upperBound()));
+      return getPhysicalPointFromDomainPoint(myDomain.upperBound());
     }
 
   ///////////////////////////////////////////////////////////////////////////////

--- a/src/DGtal/io/readers/ITKReader.ih
+++ b/src/DGtal/io/readers/ITKReader.ih
@@ -195,7 +195,7 @@ namespace DGtal {
       trace.error() << e;
       throw IOException();
     }
-    
+
     TypeDGtalImage image( itk_image );
     if (shiftDomainUsingOrigin)
     {
@@ -206,23 +206,10 @@ namespace DGtal {
         p[k] = static_cast<typename Domain::Integer>(c[k]);
       }
       image.updateDomain(p);
-      //updating only the domain is not sufficient to import correctly
-      //the itk image, in particular for the range iterator.
-      auto r = itk_image->GetBufferedRegion();
-      auto i = r.GetIndex();
-      for (Dimension k = 0; k < dimension; k++)
-      {
-        i[k] += static_cast<typename Domain::Integer>(c[k]);
-      }
-      r.SetIndex(i);
-      itk_image->SetBufferedRegion(r);
     }
-    
-    
     return image;
   }
 
-  
   template <typename I>
   template <typename Image, typename Domain, typename OrigValue,
 	    typename TFunctor, typename Value>

--- a/tests/images/testITKImage.cpp
+++ b/tests/images/testITKImage.cpp
@@ -348,14 +348,15 @@ bool testITKImageWithShiftDomain()
   nbok += ( new_upperBound == upperBound + domainShift); nb++;
   trace.info() << "upperBound: " << new_upperBound << ". Expected: " << upperBound + domainShift << std::endl;
 
-  // Check that the value of index points is not affected by a change of myDomainShift.
-  val = myImage.operator()(lowerBound);
+  // Check that the shifted domain points to the correct indices of the image.
+  val = myImage.operator()(new_lowerBound);
+  // It should have the same value than lowerBound had before applying the domainShift
   nbok += (val == 0); nb++;
-  trace.info() << "Index: " << lowerBound << ". Value: " << val << ". Expected: " << 0 << std::endl;
-  val = myImage.operator()(upperBound);
+  trace.info() << "Index: " << new_lowerBound << ". Value: " << val << ". Expected: " << 0 << std::endl;
+  val = myImage.operator()(new_upperBound);
   nbok += (val == 124); nb++;
-  trace.info() << "Index: " << upperBound << ". Value: " << val << ". Expected: " << 124 << std::endl;
-  val = myImage.operator()(c);
+  trace.info() << "Index: " << new_upperBound << ". Value: " << val << ". Expected: " << 124 << std::endl;
+  val = myImage.operator()(myImage.getDomainPointFromIndex(c));
   nbok += (val == 31); nb++;
   trace.info() << "Index: " << c << ". Value: " << val << ". Expected: " << 31 << std::endl;
 

--- a/tests/images/testITKImage.cpp
+++ b/tests/images/testITKImage.cpp
@@ -268,9 +268,10 @@ bool testITKImageWithMetadata()
   Image::PhysicalPoint expected_physical_point;
   Image::Point index_point;
 
+  // when shiftDomain is zero, index points (ITK) and domain points (DGtal) are equal
   index_point = myImage.getIndexFromDomainPoint(lowerBound);
   nbok += (index_point == lowerBound); nb++;
-  physical_point = myImage.getPhysicalPointFromIndex(index_point);
+  physical_point = myImage.getPhysicalPointFromDomainPoint(index_point);
   expected_physical_point = myImage.getLowerBoundAsPhysicalPoint();
   nbok += (physical_point[0] == 12.0); nb++;
   nbok += (physical_point == expected_physical_point); nb++;
@@ -278,13 +279,13 @@ bool testITKImageWithMetadata()
 
   index_point = myImage.getIndexFromDomainPoint(upperBound);
   nbok += (index_point == upperBound); nb++;
-  physical_point = myImage.getPhysicalPointFromIndex(index_point);
+  physical_point = myImage.getPhysicalPointFromDomainPoint(index_point);
   expected_physical_point = myImage.getUpperBoundAsPhysicalPoint();
   nbok += (physical_point[0] == 20.0); nb++;
   nbok += (physical_point == expected_physical_point); nb++;
   trace.info() << "Index: " << index_point << ". PhysicalPoint: " << physical_point << ". Expected: " << expected_physical_point << std::endl;
 
-  auto index_back = myImage.getIndexFromPhysicalPoint(physical_point);
+  auto index_back = myImage.getDomainPointFromPhysicalPoint(physical_point);
   nbok += (index_back == upperBound); nb++;
   trace.info() << "PhysicalPoint: " << physical_point << ". Index (back): " << index_back << ". Expected: " << upperBound << std::endl;
 
@@ -363,28 +364,40 @@ bool testITKImageWithShiftDomain()
   Image::PhysicalPoint physical_point;
   Image::PhysicalPoint expected_physical_point;
   Image::Point index_point;
+  Image::Point domain_point;
 
   index_point = lowerBound;
-  physical_point = myImage.getPhysicalPointFromIndex(index_point);
+  domain_point = new_lowerBound;
+  physical_point = myImage.getPhysicalPointFromDomainPoint(domain_point);
   expected_physical_point = Image::PhysicalPoint(12.0, 12.0, 12.0);
   nbok += (physical_point == expected_physical_point); nb++;
-  trace.info() << "Index: " << index_point << ". PhysicalPoint: " << physical_point << ". Expected: " << expected_physical_point << std::endl;
+  trace.info() << "Domain: " << domain_point <<
+    ". Index: " << index_point <<
+    ". PhysicalPoint: " << physical_point <<
+    ". Expected: " << expected_physical_point << std::endl;
 
   index_point = myImage.getIndexFromDomainPoint(new_lowerBound);
   nbok += ( index_point == lowerBound ); nb++;
   trace.info() << "index_point: " << index_point << ". Expected: " << lowerBound << std::endl;
-  physical_point = myImage.getPhysicalPointFromIndex(index_point);
+  physical_point = myImage.getPhysicalPointFromDomainPoint(new_lowerBound);
   expected_physical_point = myImage.getLowerBoundAsPhysicalPoint();
   nbok += (physical_point[0] == 12.0); nb++;
   nbok += (physical_point == expected_physical_point); nb++;
-  trace.info() << "Index: " << index_point << ". PhysicalPoint: " << physical_point << ". Expected: " << expected_physical_point << std::endl;
+  trace.info() << "Domain: " << new_lowerBound <<
+    ". Index: " << index_point <<
+    ". PhysicalPoint: " << physical_point <<
+    ". Expected: " << expected_physical_point << std::endl;
 
   index_point = upperBound;
-  physical_point = myImage.getPhysicalPointFromIndex(index_point);
+  domain_point = new_upperBound;
+  physical_point = myImage.getPhysicalPointFromDomainPoint(domain_point);
   expected_physical_point = myImage.getUpperBoundAsPhysicalPoint();
   nbok += (physical_point[0] == 20.0); nb++;
   nbok += (physical_point == expected_physical_point); nb++;
-  trace.info() << "Index: " << index_point << ". PhysicalPoint: " << physical_point << ". Expected: " << expected_physical_point << std::endl;
+  trace.info() << "Domain: " << new_lowerBound <<
+    ". Index: " << index_point <<
+    ". PhysicalPoint: " << physical_point <<
+    ". Expected: " << expected_physical_point << std::endl;
 
   return nbok == 11 && nb == 11;
 }


### PR DESCRIPTION
Assume that DGtal will work with points from domains, so
operator() and setValue in ImageContainerByITKImage
need to shift the input point (a domain point) to a valid
index point. When domainShift is Zero, the input point is not
affected.

Changed test to accommodate this new behavior.